### PR TITLE
Use English names of countries to be consistent

### DIFF
--- a/style.json
+++ b/style.json
@@ -1771,7 +1771,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": "{name:latin}",
+        "text-field": "{name_en}",
         "text-font": [
           "Metropolis Light Italic",
           "Noto Sans Italic"
@@ -1830,7 +1830,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": "{name:latin}",
+        "text-field": "{name_en}",
         "text-font": [
           "Metropolis Regular",
           "Noto Sans Regular"
@@ -1889,7 +1889,7 @@
       ],
       "layout": {
         "visibility": "visible",
-        "text-field": "{name:latin}",
+        "text-field": "{name_en}",
         "text-font": [
           "Metropolis Regular",
           "Noto Sans Regular"


### PR DESCRIPTION
To maintain consistency with the [default basemap](https://maps.elastic.co), we should use English names for countries. This is similar to https://github.com/elastic/osm-bright-gl-style/pull/1.

This can be reviewed by loading the style.json file into https://maputnik.github.io/editor/#0.21/0/0. 

cc @thomasneirynck