### PR TITLE
Do not show certain labels until zoom 1.1

### DIFF
--- a/style.json
+++ b/style.json
@@ -1751,6 +1751,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "place",
+      "minzoom": 1.1,
       "maxzoom": 8,
       "filter": [
         "all",
@@ -1777,6 +1778,7 @@
           "Noto Sans Italic"
         ],
         "text-transform": "uppercase",
+        "text-max-width": 6.25,
         "text-size": {
           "base": 1,
           "stops": [
@@ -1805,6 +1807,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "place",
+      "minzoom": 1.1,
       "maxzoom": 8,
       "filter": [
         "all",
@@ -1836,6 +1839,7 @@
           "Noto Sans Regular"
         ],
         "text-transform": "uppercase",
+        "text-max-width": 6.25,
         "text-size": {
           "base": 1,
           "stops": [
@@ -1864,6 +1868,7 @@
       },
       "source": "openmaptiles",
       "source-layer": "place",
+      "minzoom": 1.1,
       "maxzoom": 6,
       "filter": [
         "all",
@@ -1895,6 +1900,55 @@
           "Noto Sans Regular"
         ],
         "text-transform": "uppercase",
+        "text-max-width": 6.25,
+        "text-size": {
+          "base": 1.4,
+          "stops": [
+            [
+              0,
+              10
+            ],
+            [
+              3,
+              12
+            ],
+            [
+              4,
+              14
+            ]
+          ]
+        },
+        "text-anchor": "center"
+      },
+      "paint": {
+        "text-halo-width": 1.4,
+        "text-halo-color": "rgba(0,0,0,0.7)",
+        "text-color": "rgb(101,101,101)"
+      }
+    },
+    {
+      "id": "place_continent",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "101da9f13b64a08fa4b6ac1168e89e5f"
+      },
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 1.1,
+      "filter": [
+        "==",
+        "class",
+        "continent"
+      ],
+      "layout": {
+        "visibility": "visible",
+        "text-field": "{name_en}",
+        "text-font": [
+          "Metropolis Regular",
+          "Noto Sans Regular"
+        ],
+        "text-transform": "uppercase",
+        "text-max-width": 6.25,
         "text-size": {
           "base": 1.4,
           "stops": [


### PR DESCRIPTION
Some country and ocean labels near the dateline at zoom level 1 are getting cut off in raster tiles. This is a known issue with tileserver-gl. This changes the visible zoom level for these labels to 1.1 so these errant labels will start to appear in zoom level 2 in raster tiles and in zoom level 1.1 in vector tiles.

Instead of country labels at zoom level 1, we show continent labels which do not cross the dateline.

cf https://github.com/elastic/osm-bright-gl-style/pull/2