### PR TITLE
Use EUI dark theme colors

### DIFF
--- a/style.json
+++ b/style.json
@@ -34,7 +34,7 @@
       "id": "background",
       "type": "background",
       "paint": {
-        "background-color": "rgb(12,12,12)"
+        "background-color": "rgb(29, 30, 36)"
       }
     },
     {
@@ -51,7 +51,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(27 ,27 ,29)",
+        "fill-color": "rgb(37, 38, 46)",
         "fill-antialias": false
       }
     },
@@ -78,7 +78,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(12,12,12)",
+        "fill-color": "rgb(29, 30, 36)",
         "fill-opacity": 0.7
       }
     },
@@ -105,7 +105,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "hsl(0, 1%, 2%)",
+        "fill-color": "rgb(29, 30, 36)",
         "fill-opacity": {
           "base": 1,
           "stops": [
@@ -144,7 +144,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "hsl(0, 2%, 5%)",
+        "fill-color": "rgb(29, 30, 36)",
         "fill-opacity": 0.4
       }
     },
@@ -171,7 +171,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(32,32,32)",
+        "fill-color": "rgb(52, 55, 65)",
         "fill-opacity": {
           "base": 0.3,
           "stops": [
@@ -218,7 +218,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(32,32,32)"
+        "fill-color": "rgb(52, 55, 65)"
       }
     },
     {
@@ -235,7 +235,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(27 ,27 ,29)"
+        "line-color": "rgb(37, 38, 46)"
       }
     },
     {
@@ -260,8 +260,7 @@
         "text-size": 12
       },
       "paint": {
-        "text-color": "hsla(0, 0%, 0%, 0.7)",
-        "text-halo-color": "hsl(0, 0%, 27%)"
+        "text-color": "rgb(152, 162, 179)"
       }
     },
     {
@@ -276,8 +275,8 @@
         "Polygon"
       ],
       "paint": {
-        "fill-color": "rgb(10,10,10)",
-        "fill-outline-color": "rgb(27 ,27 ,29)",
+        "fill-color": "rgb(29, 30, 36)",
+        "fill-outline-color": "rgb(37, 38, 46)",
         "fill-antialias": true
       }
     },
@@ -304,7 +303,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#181818",
+        "line-color": "rgb(37, 38, 46)",
         "line-width": {
           "base": 1.55,
           "stops": [
@@ -344,7 +343,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgba(60,60,60,0.8)",
+        "line-color": "rgb(83, 89, 102)",
         "line-width": {
           "base": 1.5,
           "stops": [
@@ -389,7 +388,7 @@
       },
       "paint": {
         "fill-opacity": 1,
-        "fill-color": "#000"
+        "fill-color": "rgb(29, 30, 36)"
       }
     },
     {
@@ -420,7 +419,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#000",
+        "line-color": "rgb(29, 30, 36)",
         "line-width": {
           "base": 1.5,
           "stops": [
@@ -460,7 +459,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(12,12,12)",
+        "fill-color": "rgb(29, 30, 36)",
         "fill-antialias": true
       }
     },
@@ -488,7 +487,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(12,12,12)",
+        "line-color": "rgb(29, 30, 36)",
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -531,7 +530,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(27 ,27 ,29)",
+        "line-color": "rgb(37, 38, 46)",
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -582,7 +581,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#181818",
+        "line-color": "rgb(37, 38, 46)",
         "line-width": {
           "base": 1.55,
           "stops": [
@@ -630,7 +629,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgba(60,60,60,0.8)",
+        "line-color": "rgb(83, 89, 102)",
         "line-dasharray": [
           12,
           0
@@ -681,7 +680,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsl(0, 0%, 7%)",
+        "line-color": "rgb(37, 38, 46)",
         "line-width": {
           "base": 1.3,
           "stops": [
@@ -729,7 +728,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#2a2a2a",
+        "line-color": "rgb(52, 55, 65)",
         "line-width": {
           "stops": [
             [
@@ -772,7 +771,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgba(60,60,60,0.8)",
+        "line-color": "rgb(83, 89, 102)",
         "line-width": {
           "base": 1.4,
           "stops": [
@@ -830,11 +829,11 @@
           "stops": [
             [
               5.8,
-              "hsla(0, 0%, 85%, 0.53)"
+              "rgb(29, 30, 36)"
             ],
             [
               6,
-              "#000"
+              "rgb(29, 30, 36)"
             ]
           ]
         },
@@ -885,7 +884,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "#181818",
+        "line-color": "rgb(37, 38, 46)",
         "line-width": {
           "base": 1.4,
           "stops": [
@@ -936,7 +935,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(35,35,35)",
+        "line-color": "rgb(83, 89, 102)",
         "line-width": 3
       }
     },
@@ -975,7 +974,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(12,12,12)",
+        "line-color": "rgb(29, 30, 36)",
         "line-width": 2,
         "line-dasharray": [
           3,
@@ -1017,7 +1016,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(35,35,35)",
+        "line-color": "rgb(83, 89, 102)",
         "line-width": 3
       }
     },
@@ -1055,7 +1054,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(12,12,12)",
+        "line-color": "rgb(29, 30, 36)",
         "line-width": 2,
         "line-dasharray": [
           3,
@@ -1107,7 +1106,7 @@
             ]
           ]
         },
-        "line-color": "rgb(35,35,35)"
+        "line-color": "rgb(83, 89, 102)"
       }
     },
     {
@@ -1141,7 +1140,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(12,12,12)",
+        "line-color": "rgb(29, 30, 36)",
         "line-width": {
           "base": 1.3,
           "stops": [
@@ -1198,12 +1197,12 @@
         "text-field": "{name:latin} {name:nonlatin}"
       },
       "paint": {
-        "text-color": "rgba(80, 78, 78, 1)",
+        "text-color": "rgb(152, 162, 179)",
         "text-translate": [
           0,
           0
         ],
-        "text-halo-color": "rgba(0, 0, 0, 1)",
+        "text-halo-color": "rgb(29, 30, 36)",
         "text-halo-width": 1,
         "text-halo-blur": 0
       }
@@ -1243,7 +1242,7 @@
         "text-field": "{ref}"
       },
       "paint": {
-        "text-color": "hsl(0, 0%, 37%)",
+        "text-color": "rgb(152, 162, 179)",
         "text-translate": [
           0,
           2
@@ -1269,7 +1268,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsl(0, 0%, 21%)",
+        "line-color": "rgb(83, 89, 102)",
         "line-width": {
           "base": 1.3,
           "stops": [
@@ -1309,7 +1308,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "hsl(0, 0%, 23%)",
+        "line-color": "rgb(83, 89, 102)",
         "line-width": {
           "base": 1.1,
           "stops": [
@@ -1380,8 +1379,8 @@
         "text-field": "{name:latin}\n{name:nonlatin}"
       },
       "paint": {
-        "text-color": "rgb(101,101,101)",
-        "text-halo-color": "rgba(0,0,0,0.7)",
+        "text-color": "rgb(152, 162, 179)",
+        "text-halo-color": "rgb(29, 30, 36)",
         "text-halo-width": 1,
         "text-halo-blur": 1
       }
@@ -1425,8 +1424,8 @@
         "text-field": "{name:latin}\n{name:nonlatin}"
       },
       "paint": {
-        "text-color": "rgb(101,101,101)",
-        "text-halo-color": "rgba(0,0,0,0.7)",
+        "text-color": "rgb(152, 162, 179)",
+        "text-halo-color": "rgb(29, 30, 36)",
         "text-halo-width": 1,
         "text-halo-blur": 1
       }
@@ -1471,8 +1470,8 @@
         "text-field": "{name:latin}\n{name:nonlatin}"
       },
       "paint": {
-        "text-color": "rgb(101,101,101)",
-        "text-halo-color": "rgba(0,0,0,0.7)",
+        "text-color": "rgb(152, 162, 179)",
+        "text-halo-color": "rgb(29, 30, 36)",
         "text-halo-width": 1,
         "text-halo-blur": 1,
         "icon-opacity": 0.7
@@ -1543,8 +1542,8 @@
         "text-field": "{name:latin}\n{name:nonlatin}"
       },
       "paint": {
-        "text-color": "rgb(101,101,101)",
-        "text-halo-color": "rgba(0,0,0,0.7)",
+        "text-color": "rgb(152, 162, 179)",
+        "text-halo-color": "rgb(29, 30, 36)",
         "text-halo-width": 1,
         "text-halo-blur": 1,
         "icon-opacity": 0.7
@@ -1620,8 +1619,8 @@
         "text-field": "{name:latin}\n{name:nonlatin}"
       },
       "paint": {
-        "text-color": "rgb(101,101,101)",
-        "text-halo-color": "rgba(0,0,0,0.7)",
+        "text-color": "rgb(152, 162, 179)",
+        "text-halo-color": "rgb(29, 30, 36)",
         "text-halo-width": 1,
         "text-halo-blur": 1,
         "icon-opacity": 0.7
@@ -1697,8 +1696,8 @@
         "text-field": "{name:latin}\n{name:nonlatin}"
       },
       "paint": {
-        "text-color": "rgb(101,101,101)",
-        "text-halo-color": "rgba(0,0,0,0.7)",
+        "text-color": "rgb(152, 162, 179)",
+        "text-halo-color": "rgb(29, 30, 36)",
         "text-halo-width": 1,
         "text-halo-blur": 1,
         "icon-opacity": 0.7
@@ -1737,8 +1736,8 @@
         "text-size": 10
       },
       "paint": {
-        "text-color": "rgb(101,101,101)",
-        "text-halo-color": "rgba(0,0,0,0.7)",
+        "text-color": "rgb(152, 162, 179)",
+        "text-halo-color": "rgb(29, 30, 36)",
         "text-halo-width": 1,
         "text-halo-blur": 1
       }
@@ -1795,8 +1794,8 @@
       },
       "paint": {
         "text-halo-width": 1.4,
-        "text-halo-color": "rgba(0,0,0,0.7)",
-        "text-color": "rgb(101,101,101)"
+        "text-halo-color": "rgb(29, 30, 36)",
+        "text-color": "rgb(152, 162, 179)"
       }
     },
     {
@@ -1856,8 +1855,8 @@
       },
       "paint": {
         "text-halo-width": 1.4,
-        "text-halo-color": "rgba(0,0,0,0.7)",
-        "text-color": "rgb(101,101,101)"
+        "text-halo-color": "rgb(29, 30, 36)",
+        "text-color": "rgb(152, 162, 179)"
       }
     },
     {
@@ -1922,8 +1921,8 @@
       },
       "paint": {
         "text-halo-width": 1.4,
-        "text-halo-color": "rgba(0,0,0,0.7)",
-        "text-color": "rgb(101,101,101)"
+        "text-halo-color": "rgb(29, 30, 36)",
+        "text-color": "rgb(152, 162, 179)"
       }
     },
     {
@@ -1970,8 +1969,8 @@
       },
       "paint": {
         "text-halo-width": 1.4,
-        "text-halo-color": "rgba(0,0,0,0.7)",
-        "text-color": "rgb(101,101,101)"
+        "text-halo-color": "rgb(29, 30, 36)",
+        "text-color": "rgb(152, 162, 179)"
       }
     }
   ],

--- a/style.json
+++ b/style.json
@@ -34,7 +34,7 @@
       "id": "background",
       "type": "background",
       "paint": {
-        "background-color": "rgb(29, 30, 36)"
+        "background-color": "rgb(22, 26, 28)"
       }
     },
     {
@@ -51,7 +51,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(37, 38, 46)",
+        "fill-color": "rgb(34, 34, 32)",
         "fill-antialias": false
       }
     },
@@ -78,7 +78,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(29, 30, 36)",
+        "fill-color": "rgb(22, 26, 28)",
         "fill-opacity": 0.7
       }
     },
@@ -105,7 +105,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(29, 30, 36)",
+        "fill-color": "rgb(22, 26, 28)",
         "fill-opacity": {
           "base": 1,
           "stops": [
@@ -144,7 +144,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(29, 30, 36)",
+        "fill-color": "rgb(22, 26, 28)",
         "fill-opacity": 0.4
       }
     },
@@ -235,7 +235,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(37, 38, 46)"
+        "line-color": "rgb(34, 34, 32)"
       }
     },
     {
@@ -275,8 +275,8 @@
         "Polygon"
       ],
       "paint": {
-        "fill-color": "rgb(29, 30, 36)",
-        "fill-outline-color": "rgb(37, 38, 46)",
+        "fill-color": "rgb(22, 26, 28)",
+        "fill-outline-color": "rgb(34, 34, 32)",
         "fill-antialias": true
       }
     },
@@ -303,7 +303,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(37, 38, 46)",
+        "line-color": "rgb(34, 34, 32)",
         "line-width": {
           "base": 1.55,
           "stops": [
@@ -388,7 +388,7 @@
       },
       "paint": {
         "fill-opacity": 1,
-        "fill-color": "rgb(29, 30, 36)"
+        "fill-color": "rgb(22, 26, 28)"
       }
     },
     {
@@ -419,7 +419,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(29, 30, 36)",
+        "line-color": "rgb(22, 26, 28)",
         "line-width": {
           "base": 1.5,
           "stops": [
@@ -459,7 +459,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "rgb(29, 30, 36)",
+        "fill-color": "rgb(22, 26, 28)",
         "fill-antialias": true
       }
     },
@@ -487,7 +487,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(29, 30, 36)",
+        "line-color": "rgb(22, 26, 28)",
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -530,7 +530,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(37, 38, 46)",
+        "line-color": "rgb(34, 34, 32)",
         "line-width": {
           "base": 1.2,
           "stops": [
@@ -581,7 +581,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(37, 38, 46)",
+        "line-color": "rgb(34, 34, 32)",
         "line-width": {
           "base": 1.55,
           "stops": [
@@ -680,7 +680,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(37, 38, 46)",
+        "line-color": "rgb(34, 34, 32)",
         "line-width": {
           "base": 1.3,
           "stops": [
@@ -829,11 +829,11 @@
           "stops": [
             [
               5.8,
-              "rgb(29, 30, 36)"
+              "rgb(22, 26, 28)"
             ],
             [
               6,
-              "rgb(29, 30, 36)"
+              "rgb(22, 26, 28)"
             ]
           ]
         },
@@ -884,7 +884,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "rgb(37, 38, 46)",
+        "line-color": "rgb(34, 34, 32)",
         "line-width": {
           "base": 1.4,
           "stops": [
@@ -974,7 +974,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(29, 30, 36)",
+        "line-color": "rgb(22, 26, 28)",
         "line-width": 2,
         "line-dasharray": [
           3,
@@ -1054,7 +1054,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(29, 30, 36)",
+        "line-color": "rgb(22, 26, 28)",
         "line-width": 2,
         "line-dasharray": [
           3,
@@ -1140,7 +1140,7 @@
         "line-join": "round"
       },
       "paint": {
-        "line-color": "rgb(29, 30, 36)",
+        "line-color": "rgb(22, 26, 28)",
         "line-width": {
           "base": 1.3,
           "stops": [
@@ -1202,7 +1202,7 @@
           0,
           0
         ],
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-halo-width": 1,
         "text-halo-blur": 0
       }
@@ -1380,7 +1380,7 @@
       },
       "paint": {
         "text-color": "rgb(152, 162, 179)",
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-halo-width": 1,
         "text-halo-blur": 1
       }
@@ -1425,7 +1425,7 @@
       },
       "paint": {
         "text-color": "rgb(152, 162, 179)",
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-halo-width": 1,
         "text-halo-blur": 1
       }
@@ -1471,7 +1471,7 @@
       },
       "paint": {
         "text-color": "rgb(152, 162, 179)",
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-halo-width": 1,
         "text-halo-blur": 1,
         "icon-opacity": 0.7
@@ -1543,7 +1543,7 @@
       },
       "paint": {
         "text-color": "rgb(152, 162, 179)",
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-halo-width": 1,
         "text-halo-blur": 1,
         "icon-opacity": 0.7
@@ -1620,7 +1620,7 @@
       },
       "paint": {
         "text-color": "rgb(152, 162, 179)",
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-halo-width": 1,
         "text-halo-blur": 1,
         "icon-opacity": 0.7
@@ -1697,7 +1697,7 @@
       },
       "paint": {
         "text-color": "rgb(152, 162, 179)",
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-halo-width": 1,
         "text-halo-blur": 1,
         "icon-opacity": 0.7
@@ -1737,7 +1737,7 @@
       },
       "paint": {
         "text-color": "rgb(152, 162, 179)",
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-halo-width": 1,
         "text-halo-blur": 1
       }
@@ -1794,7 +1794,7 @@
       },
       "paint": {
         "text-halo-width": 1.4,
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-color": "rgb(152, 162, 179)"
       }
     },
@@ -1855,7 +1855,7 @@
       },
       "paint": {
         "text-halo-width": 1.4,
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-color": "rgb(152, 162, 179)"
       }
     },
@@ -1921,7 +1921,7 @@
       },
       "paint": {
         "text-halo-width": 1.4,
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-color": "rgb(152, 162, 179)"
       }
     },
@@ -1969,7 +1969,7 @@
       },
       "paint": {
         "text-halo-width": 1.4,
-        "text-halo-color": "rgb(29, 30, 36)",
+        "text-halo-color": "rgb(22, 26, 28)",
         "text-color": "rgb(152, 162, 179)"
       }
     }


### PR DESCRIPTION
wrt https://github.com/elastic/kibana/issues/38147

I took a rather naive approach to matching the map layer colors to the [EUI Dark theme color palette](https://elastic.github.io/eui/#/guidelines/colors). The label colors stand out a bit better, but I'd like to get some feedback from others.

[Preview this style](https://maputnik.github.io/editor/?style=https://raw.githubusercontent.com/elastic/dark-matter-gl-style/c0b2ca46bb41ea2610120f554bc80d688d42030a/style.json#0.21/0/0)

Before
![Before](https://user-images.githubusercontent.com/1638483/59075432-4ddf0480-8885-11e9-9c4a-7a73f155a560.png)

After
![After](https://user-images.githubusercontent.com/1638483/59075429-4ae41400-8885-11e9-9a73-f007c6a4c91a.png)
